### PR TITLE
Update links after developer portal changed /more => /all

### DIFF
--- a/alpha.md
+++ b/alpha.md
@@ -41,5 +41,5 @@ This is not an official Apple website. [Please consider donating](https://paypal
 ---
 
 <ul>
-  <li><a name="fn1"></a>¹ - If the direct download link doesn't work, you can find most downloads on <a href="https://developer.apple.com/download/more">developer.apple.com/download/more</a>.<br />Alternatively, make sure you're logged in to developer.apple.com, and then reload xcodereleases.com. <a href="#ret-fn1">[↑]</a></li>
+  <li><a name="fn1"></a>¹ - If the direct download link doesn't work, you can find most downloads on <a href="https://developer.apple.com/download/all/">developer.apple.com/download/all</a>.<br />Alternatively, make sure you're logged in to developer.apple.com, and then reload xcodereleases.com. <a href="#ret-fn1">[↑]</a></li>
 </ul>

--- a/index.md
+++ b/index.md
@@ -51,5 +51,5 @@ Looking for an API? The data for this site is available at <a href="{{ site.url 
 ---
 
 <ul>
-  <li><a name="fn1"></a>¹ - If the direct download link doesn't work, you can find most downloads on <a href="https://developer.apple.com/download/more">developer.apple.com/download/more</a>.<br />Alternatively, make sure you're logged in to developer.apple.com, and then reload xcodereleases.com. <a href="#ret-fn1">[↑]</a></li>
+  <li><a name="fn1"></a>¹ - If the direct download link doesn't work, you can find most downloads on <a href="https://developer.apple.com/download/all/">developer.apple.com/download/all/</a>.<br />Alternatively, make sure you're logged in to developer.apple.com, and then reload xcodereleases.com. <a href="#ret-fn1">[↑]</a></li>
 </ul>


### PR DESCRIPTION
https://developer.apple.com/download/more 404's now, https://developer.apple.com/download/all/ is the new home for the list of everything with a search box