### PR TITLE
Switch twitter URL to mastodon.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,6 @@ github:
   owner_gravatar_url:
   public: false
   owner_name: Xcode Releases
-  owner_url: https://twitter.com/xcodereleases
+  owner_url: https://techhub.social/@xcodereleases
 
 repository: xcodereleases/xcodereleases.com


### PR DESCRIPTION
Twitter account says "Not posting updates for the forseeable [sic] future", and it seems like the Mastodon account is active.