### PR TITLE
Added latest.json to APIs

### DIFF
--- a/api/latest.json
+++ b/api/latest.json
@@ -1,0 +1,14 @@
+---
+layout: null
+---
+{%- assign releaseTypes = "release,rc,beta" | split: "," -%}
+{%- assign xcodes = "" | split: "," -%}
+{%- for release in site.data.releases -%}
+    {%- for releaseType in releaseTypes -%}
+        {%- if release.version.release contains releaseType -%}
+            {%- assign xcodes = xcodes | push: release -%}
+            {%- assign releaseTypes = releaseTypes | where_exp: "rt", "rt != releaseType" -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endfor -%}
+{{ xcodes | jsonify }}


### PR DESCRIPTION
Hey! I love this site, and found a use case where this would be useful

It shows only the latest version of each release type, or at least the ones listed in the template (so, the latest release, the latest GM, the latest beta, etc)

Some notes:
- Don't know if this could be as useful as a RSS feed so I didn't add it for now, but I'm open for feedback on this.
- I couldn't find a way to map release types without listing them by hand in the template, so I put them at the top so they're easy to locate and update whenever Apple changes its release naming scheme