### PR TITLE
Fix: Correct label 'for' attribute for Releases filter

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Stay up-to-date via our [JSON API]({{ site.url }}/data.json), [RSS feed]({{ site
   <label for="filter-all">All</label>
 
   <input type="radio" name="filter-release" id="filter-releases" value="release" onchange="filter()" />
-  <label for="filter-release">Releases</label>
+  <label for="filter-releases">Releases</label>
 
   <input type="radio" name="filter-release" id="filter-beta" value="beta" onchange="filter()" />
   <label for="filter-beta">Betas</label>


### PR DESCRIPTION
## Summary

Fix "Releases" filter label association.

## Problem

`<label for="filter-release">` mismatched the radio button `<input id="filter-releases">`.

## Solution

Corrected the for attribute to filter-releases so clicking the label works.